### PR TITLE
Add initial instrumentation to the job controller

### DIFF
--- a/controllers/job_controller_metrics.go
+++ b/controllers/job_controller_metrics.go
@@ -1,0 +1,22 @@
+package controllers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricReconciliationsStarted = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "preflightcheck_job_reconciliations_started",
+		Help: "The total number of job reconciliations started.",
+	})
+
+	metricReconciliationsCompleted = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "preflightcheck_job_reconciliations_completed",
+		Help: "The total number of job reconciliations that reach are ended without needing a requeue.",
+	})
+
+	metricReconciliationsErrored = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "preflightcheck_job_reconciliations_errored",
+		Help: "The total number of job reconciliations that reach an error before completion.",
+	})
+)

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -1,0 +1,14 @@
+package controllers
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(
+		metricReconciliationsStarted,
+		metricReconciliationsErrored,
+		metricReconciliationsCompleted,
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/opdev/preflight-controller
 go 1.17
 
 require (
-	github.com/imdario/mergo v0.3.12
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/opdev/subreconciler v0.0.0-20220322135903-3c30797862ba
+	github.com/prometheus/client_golang v1.11.0
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
@@ -36,13 +36,13 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect


### PR DESCRIPTION
This PR just adds 3 reconciliation metrics outlining the job reconcilier's happy and unhappy paths. Mostly a PoC to guide the creation of additional metrics.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>